### PR TITLE
Update get_baseurl_from_conn/1

### DIFF
--- a/lib/elixir_auth_microsoft.ex
+++ b/lib/elixir_auth_microsoft.ex
@@ -164,13 +164,7 @@ defmodule ElixirAuthMicrosoft do
     System.get_env("MICROSOFT_CALLBACK_PATH") || @default_callback_path
   end
 
-
-  defp get_baseurl_from_conn(%{host: h, port: p}) when h == "localhost" do
-    "http://#{h}:#{p}"
+  defp get_baseurl_from_conn(%{scheme: s, host: h, port: p}) do
+    "#{s}://#{h}:#{p}"
   end
-
-  defp get_baseurl_from_conn(%{host: h}) do
-    "https://#{h}"
-  end
-
 end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ElixirAuthMicrosoft.MixProject do
   def project do
     [
       app: :elixir_auth_microsoft,
-      version: "1.1.1",
+      version: "1.1.2",
       elixir: "~> 1.12",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
- Updated get_baseurl_from_conn/1 to set scheme, host and port rather than custom port only for localhost
- Bump version to 1.1.2